### PR TITLE
Ajout d'une API codée en Python 3 et testée ainsi que documentée

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    evasion.py is an API which allows to detect and control an .évasion box from VOO
+    Copyright (C) 2019 Vincent STRAGIER
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    evasion.py  Copyright (C) 2019 Vincent STRAGIER
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/evasion_API_Python3/.evasion_API.md
+++ b/evasion_API_Python3/.evasion_API.md
@@ -4,6 +4,38 @@ Ayant découvert ce [post](https://forum.voo.be/ma-box-evasion-10/api-de-la-box-
 
 Attention, il est possible que votre pare-feu bloque l'exécution de cette API. Si tel est le cas tester l'API sans pare-feu et ajouter une autorisation pour le script (normalement seul le port 5900 est utilisé).
 
+## LICENSE
+
+> ​    evasion.py is an API which allows to detect and control an .évasion box from VOO
+>
+> ​    Copyright (C) 2019 Vincent STRAGIER (vincent.stragier@outlook.com)
+>
+> 
+>
+> ​    This program is free software: you can redistribute it and/or modify
+>
+> ​    it under the terms of the GNU General Public License as published by
+>
+> ​    the Free Software Foundation, either version 3 of the License, or
+>
+> ​    (at your option) any later version.
+>
+> 
+>
+> ​    This program is distributed in the hope that it will be useful,
+>
+> ​    but WITHOUT ANY WARRANTY; without even the implied warranty of
+>
+> ​    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+>
+> ​    GNU General Public License for more details.
+>
+> 
+>
+> ​    You should have received a copy of the GNU General Public License
+>
+> ​    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 ## Installation et *requirements*
 
 L'API a été développé sous Python 3 (sous Windows 10 et Debian). La détection de la box nécessite l'installation du module `netifaces`. L'installation de ce module est optionnel, car il n'est nécessaire que pour l'option de recherche de la box.

--- a/evasion_API_Python3/.evasion_API.md
+++ b/evasion_API_Python3/.evasion_API.md
@@ -1,0 +1,236 @@
+# .evasion-API
+
+Ayant découvert ce [post](https://forum.voo.be/ma-box-evasion-10/api-de-la-box-evasion-7227) sur le forum de VOO et ce [GitHub](https://github.com/FiReBlUe45/VOO-Evasion-API) parlant de la création d'une API pour la box .evasion, je me suis lancé dans la création d'une API permettant de contrôler la box par le biais du réseau, mais aussi de trouver son adresse IP (probable), d'afficher les commandes connues et d'effectuer une conversion du nom de la commande au code envoyé et vice versa.
+
+Attention, il est possible que votre pare-feu bloque l'exécution de cette API. Si tel est le cas tester l'API sans pare-feu et ajouter une autorisation pour le script (normalement seul le port 5900 est utilisé).
+
+## Installation et *requirements*
+
+L'API a été développé sous Python 3 (sous Windows 10 et Debian). La détection de la box nécessite l'installation du module `netifaces`. L'installation de ce module est optionnel, car il n'est nécessaire que pour l'option de recherche de la box.
+
+### Sous Linux
+
+Installation de `python3` et de `pip3` afin d'installer `netifaces`, en ouvrant un terminal ou en SSH :
+
+> sudo apt update
+>
+> sudo apt upgrade
+>
+> sudo apt install -y python3 pip3 python3-pip
+>
+> pip3 install netifaces
+
+
+
+### Sous Windows
+
+Installation de `Python 3` (`pip` est installé automatiquement) :
+
+1. télécharger la dernière version stable de Python 3 sur le site du logiciel;
+2. installer l'exécutable.
+
+Installation de `netifaces` :
+
+1. en tant qu'administrateur, dans l'invité des commandes (`Windows` + `R`, *`cmd`*, `SHIFT` + `MAJ` + `ENTER`) ou dans PowerShell (`Windows` + `X`, `A`, "`Oui`");
+2. saisir `py -3 -m pip install netifaces` .
+
+
+
+## Description de l'API
+
+L'API est un simple script Python qui se trouve dans une machine qui est sur le même réseau que la box .evasion. Il suffit donc de lancer le script (**sans** les droits de l'administrateur) avec les options souhaitées.
+
+`py .\evasion.py -h` lance l'aide de l'API et affiche toutes les options disponibles :
+
+##### Remarque : `py` peut-être remplacé par `py -3` sous Windows et par `python3` sous Linux qui ne connait pas cette commande.
+
+> PS C:\User\chemin_vers_API> py .\\evasion.py -h
+> usage: evasion.py [-h] [-v] [-f] [-s] [-a ADDRESS] [-p PORT]
+>                   [-c COMMAND [COMMAND ...]] [-ch CHANNEL] [-vol VOLUME]
+>                   [-cv CONVERT_COMMAND [CONVERT_COMMAND ...]] [-lc]
+>
+> optional arguments:
+>   -h, --help            show this help message and exit
+>   -v, --verbose         increase output verbosity
+>   -f, --find            return a list of potential .evasion boxes.
+>   -s, --status          return 'success' if the command has been send else it
+>                         return 'fail'.
+>   -a ADDRESS, --address ADDRESS
+>                         IP address of the .evasion box
+>   -p PORT, --port PORT  port of the .evasion box, default is 5900 [optional]
+>   -c COMMAND [COMMAND ...], --command COMMAND [COMMAND ...]
+>                         command to send to the .evasion box (the command is
+>                         checked), name of the command and value are accepted
+>   -ch CHANNEL, --channel CHANNEL
+>                         send the command to the .evasion box to change the
+>                         channel (must be an integer)
+>   -vol VOLUME, --volume VOLUME
+>                         send the command to the .evasion box to change the
+>                         volume (must be an integer [0-20])
+>   -cv CONVERT_COMMAND [CONVERT_COMMAND ...], --convert_command CONVERT_COMMAND [CONVERT_COMMAND ...]
+>                         convert a valid command from name to value or from
+>                         value to name
+>   -lc, --list_commands  display the list of known commands
+
+
+
+### Liste des options
+
+- -h, --help : affiche l'aide du programme et le quitte;
+- -v, --verbose : permet au programme d'afficher plus d'informations lors de son exécution;
+- -f, --find : permet d'effectuer une recherche de la box .evasion en se basant sur l'ouverture du port utilisé pour le protocole [RFB](https://fr.wikipedia.org/wiki/Remote_Frame_Buffer) et en effectuant une connexion ainsi qu'un *handshake* typique à la box;
+- -s, --status : permet de savoir si l'envoie de la commande a bien eu lieu (on ne sait cependant pas si elle sera prise en compte par la box);
+- -a, --address : permet de spécifier l'adresse vers laquelle envoyer la commande;
+- -p, --port : permet de changer le port de destination (par default, le port 5900 est le port utilisé et **il ne sert donc à rien de fournir une valeur**);
+- -c,  --command : permet de spécifier la commande (nom ou valeur) à envoyer à la box (voir **liste des commandes**), le programme n'est pas sensible à la casse;
+- -ch, --channel : permet de changer de chaîne en envoyant un entier (seul la valeur absolue est prise en compte);
+- -vol, --volume : permet de changer le volume de la box pour un niveau entre 0 et 20;
+- -cv, --convert_command : permet de convertir une commande en son nom ou en sa valeur;
+- -lc, --list_commands : affiche la liste des commandes connues.
+
+A priori, les options qui nous intéresse le plus sont -a, -c, -s, -f et -lc. L'option -v est plus destinée à réalisé du débogue, -cv n'est pas vraiment utile.
+
+
+
+### Liste des commandes
+
+| Nom de la commande | Valeur |
+| ------------------ | ------ |
+| REMOTE_0           | 58112  |
+| REMOTE_1           | 58113  |
+| REMOTE_2           | 58114  |
+| REMOTE_3           | 58115  |
+| REMOTE_4           | 58116  |
+| REMOTE_5           | 58117  |
+| REMOTE_6           | 58118  |
+| REMOTE_7           | 58119  |
+| REMOTE_8           | 58120  |
+| REMOTE_9           | 58121  |
+| FAST_REVERSE       | 58375  |
+| FAST_FORWARD       | 58373  |
+| PLAY               | 58368  |
+| MUTE               | 57349  |
+| STAND_BY           | 57344  |
+| STOP               | 58370  |
+| RECORD             | 58371  |
+| TV                 | 57360  |
+| VOD                | 61224  |
+| GUIDE              | 57355  |
+| INFO               | 57358  |
+| MY_RECORDINGS      | 61235  |
+| VIDEO_WALL         | 61234  |
+| APPLICATION        | 57352  |
+| BE_ON_DEMAND       | 61236  |
+| BACK               | 57346  |
+| HOME               | 61184  |
+| VOL_UP             | 57347  |
+| VOL_DOWN           | 57348  |
+| UP                 | 57600  |
+| DOWN               | 57601  |
+| LEFT               | 57602  |
+| RIGHT              | 57603  |
+| RED_KEY            | 57856  |
+| BE_TV              | 57359  |
+| OK                 | 57345  |
+
+
+
+## Utilisation de l'API
+
+Démonstration des fonctionnalités de l'API.
+
+### Scan du réseau
+
+`py .\evasion.py -f -v` lance un scan du réseau en mode *verbose* depuis l'hôte sur lequel le script est exécuté. L'interface réseau par défaut est utilisée, ensuite, les adresses IP du réseau sont calculés pour finalement être analysées par différents process.
+
+> PS C:\User\chemin_vers_API> py .\\evasion.py -f -v
+> Verbosity turned on.
+>
+> Arguments:
+>
+> 'verbose': True
+> 'find': True
+> 'status': False
+> 'port': 5900
+> 'command': None
+> 'raw_command': None
+> 'convert_command': None
+> 'list_commands': False
+>
+> Start scanning network (this is a CPU intensive task, which needs the 'netifaces' module):
+> 192.168.0.0/24
+> Pool size (max=256): 200
+> ['192.168.0.15']
+> Scan is done
+> Potential .evasion box:
+> IP: 192.168.0.15
+
+`py .\evasion.py -f` idem ici, mais sans toutes les informations apportées par l'option *verbose*.
+
+> PS C:\User\chemin_vers_API> py .\\evasion.py -f
+> Start scanning network (this is a CPU intensive task, which needs the 'netifaces' module):
+> Potential .evasion box:
+> IP: 192.168.0.15
+
+### Affichage de la liste des commandes
+
+`py .\evasion.py -lc` affiche la liste des commandes connues.
+
+> PS C:\User\chemin_vers_API> py .\\evasion.py -lc
+> APPLICATION = 57352
+> BACK = 57346
+> BE_ON_DEMAND = 61236
+> BE_TV = 57359
+> DOWN = 57601
+> FAST_FORWARD = 58373
+> FAST_REVERSE = 58375
+> GUIDE = 57355
+> HOME = 61184
+> INFO = 57358
+> LEFT = 57602
+> MUTE = 57349
+> MY_RECORDINGS = 61235
+> OK = 57345
+> PLAY = 58368
+> RECORD = 58371
+> RED_KEY = 57856
+> REMOTE_0 = 58112
+> REMOTE_1 = 58113
+> REMOTE_2 = 58114
+> REMOTE_4 = 58116
+> REMOTE_6 = 58118
+> REMOTE_7 = 58119
+> REMOTE_8 = 58120
+> REMOTE_9 = 58121
+> RIGHT = 57603
+> STAND_BY = 57344
+> STOP = 58370
+> TV = 57360
+> UP = 57600
+> VIDEO_WALL = 61234
+> VOD = 61224
+> VOL_DOWN = 57348
+> VOL_UP = 57347
+
+### Conversion de commandes
+
+`py .\evasion.py -cv NOM_COMMANDE_OU_VALEUR_1 [NOM_COMMANDE_OU_VALEUR_2] [...]`  permet de convertir un nom ou une valeur de command en sa valeur ou en son nom.
+
+> PS C:\User\chemin_vers_API> py .\\evasion.py -cv tv
+> 57360
+> PS C:\User\chemin_vers_API> py .\\evasion.py -cv 57600
+> UP
+
+### Envoie de commandes
+
+`py .\evasion.py -a 192.168.0.x -c NOM_COMMANDE_OU_VALEUR_1 [NOM_COMMANDE_OU_VALEUR_2] [...]` où `192.168.0.x` est l'adresse IP de votre box .evasion (pensez à lui imposer une IP fixe sur base de son adresse MAC depuis le modem VOO).
+
+Veuillez noter que cette commande ne retourne rien. L'utilisation de l'option `-s` est donc une bonne option si vous souhaitez avoir un retour sur le statut de l'envoie ("Success"/"Fail").
+
+### Changer de chaîne
+
+`py .\evasion.py -a 192.168.0.x -ch NUMÉRO_DE_CHAÎNE`, tout comme la commande précédente il n'y a aucun retour et l'option `-s` peut être utiliser de la même manière.
+
+### Changer de volume
+
+`py .\evasion.py -a 192.168.0.x -vol NIVEAU_SONORE_ENTRE_0_ET_20`, tout comme les commandes précédentes il n'y a aucun retour et l'option `-s` peut être utiliser de la même manière.

--- a/evasion_API_Python3/.evasion_API.md
+++ b/evasion_API_Python3/.evasion_API.md
@@ -46,7 +46,7 @@ L'API est un simple script Python qui se trouve dans une machine qui est sur le 
 
 > PS C:\User\chemin_vers_API> py .\\evasion.py -h
 > usage: evasion.py [-h] [-v] [-f] [-s] [-a ADDRESS] [-p PORT]
->                   [-c COMMAND [COMMAND ...]] [-ch CHANNEL] [-vol VOLUME]
+>                   [-c COMMAND [COMMAND ...]] [-ch CHANNEL]
 >                   [-cv CONVERT_COMMAND [CONVERT_COMMAND ...]] [-lc]
 >
 > optional arguments:
@@ -64,9 +64,6 @@ L'API est un simple script Python qui se trouve dans une machine qui est sur le 
 >   -ch CHANNEL, --channel CHANNEL
 >                         send the command to the .evasion box to change the
 >                         channel (must be an integer)
->   -vol VOLUME, --volume VOLUME
->                         send the command to the .evasion box to change the
->                         volume (must be an integer [0-20])
 >   -cv CONVERT_COMMAND [CONVERT_COMMAND ...], --convert_command CONVERT_COMMAND [CONVERT_COMMAND ...]
 >                         convert a valid command from name to value or from
 >                         value to name
@@ -84,7 +81,6 @@ L'API est un simple script Python qui se trouve dans une machine qui est sur le 
 - -p, --port : permet de changer le port de destination (par default, le port 5900 est le port utilisé et **il ne sert donc à rien de fournir une valeur**);
 - -c,  --command : permet de spécifier la commande (nom ou valeur) à envoyer à la box (voir **liste des commandes**), le programme n'est pas sensible à la casse;
 - -ch, --channel : permet de changer de chaîne en envoyant un entier (seul la valeur absolue est prise en compte);
-- -vol, --volume : permet de changer le volume de la box pour un niveau entre 0 et 20;
 - -cv, --convert_command : permet de convertir une commande en son nom ou en sa valeur;
 - -lc, --list_commands : affiche la liste des commandes connues.
 
@@ -229,8 +225,4 @@ Veuillez noter que cette commande ne retourne rien. L'utilisation de l'option `-
 
 ### Changer de chaîne
 
-`py .\evasion.py -a 192.168.0.x -ch NUMÉRO_DE_CHAÎNE`, tout comme la commande précédente il n'y a aucun retour et l'option `-s` peut être utiliser de la même manière.
-
-### Changer de volume
-
-`py .\evasion.py -a 192.168.0.x -vol NIVEAU_SONORE_ENTRE_0_ET_20`, tout comme les commandes précédentes il n'y a aucun retour et l'option `-s` peut être utiliser de la même manière.
+`py .\evasion.py -a 192.168.0.x -ch NUMÉRO_DE_CHAÎNE`, tout comme la commande précédente il n'y a aucun retour et l'option `-s` peut être utilisée de la même manière.

--- a/evasion_API_Python3/evasion.py
+++ b/evasion_API_Python3/evasion.py
@@ -1,0 +1,497 @@
+"""
+    evasion.py is an API which allows to detect and control an .évasion box from VOO
+    Copyright (C) 2019 Vincent STRAGIER (vincent.stragier@outlook.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import print_function
+import argparse
+import socket
+import os
+import sys
+
+command = dict()
+command["REMOTE_0"] = 58112
+command["REMOTE_1"] = 58113
+command["REMOTE_2"] = 58114
+command["REMOTE_3"] = 58115
+command["REMOTE_4"] = 58116
+command["REMOTE_5"] = 58117
+command["REMOTE_6"] = 58118
+command["REMOTE_7"] = 58119
+command["REMOTE_8"] = 58120
+command["REMOTE_9"] = 58121
+command["FAST_REVERSE"] = 58375
+command["FAST_FORWARD"] = 58373
+command["PLAY"] = 58368
+command["MUTE"] = 57349
+command["STAND_BY"] = 57344
+command["STOP"] = 58370
+command["RECORD"] = 58371
+command["TV"] = 57360
+command["VOD"] = 61224
+command["GUIDE"] = 57355
+command["INFO"] = 57358
+command["MY_RECORDINGS"] = 61235
+command["VIDEO_WALL"] = 61234
+command["APPLICATION"] = 57352
+command["BE_ON_DEMAND"] = 61236
+command["BACK"] = 57346
+command["HOME"] = 61184
+command["VOL_UP"] = 57347
+command["VOL_DOWN"] = 57348
+command["UP"] = 57600
+command["DOWN"] = 57601
+command["LEFT"] = 57602
+command["RIGHT"] = 57603
+command["RED_KEY"] = 57856
+command["BE_TV"] = 57359
+command["OK"] = 57345
+
+command_ls = list(command.keys())
+
+# Allows to mask print() to the user
+class manageVerbose:
+    def __init__(self, verbose=True):
+        self.verbosity = verbose
+        
+    def __enter__(self):
+        if self.verbosity == False:
+            self._original_stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.verbosity == False:
+            sys.stdout.close()
+            sys.stdout = self._original_stdout
+
+# Check the behaviour of the connection mechanism to detect the .evasion box(es)        
+def isRFBandLikeVOOevasion(ip, port=5900, timeout=2, verbose=False):
+    with socket.socket(socket.AF_INET,socket.SOCK_STREAM) as tcp:
+        try:
+            tcp.settimeout(timeout)
+            tcp.connect((ip, port))
+            serverMSG = tcp.recv(4096)
+            
+            if not serverMSG[0:3] == b'RFB':  # Not using RFB
+                # print(serverMSG)
+                return False
+
+            tcp.send(serverMSG) # Continue the handcheck
+
+            serverMSG = tcp.recv(4096)
+
+            if not serverMSG == b'\x01\x01': # Security is not the same as on the .evasion box
+                # print(serverMSG)
+                return False
+
+            tcp.send(b'\x01')
+            serverMSG = tcp.recv(4096)
+
+            if not serverMSG == b'\x00\x00\x00\x00': # ?? Error about security negociation
+                return False
+
+            tcp.send(b'\x01')
+            serverMSG = tcp.recv(4096)
+
+            if serverMSG == bytes(24):
+                return True
+            # print(len(serverMSG))
+            return False
+        
+        except Exception as e:
+            if verbose:
+                print(e)
+            return False
+
+# Remove all the element corresponding to the "value_to_remove" from "the_list" and return a list
+def purgeList(the_list, value_to_remove):
+    temp = list()
+    for i in the_list:
+        if not i == value_to_remove:
+            temp.append(i)
+    return temp
+
+# NOT WORKING
+def commandToSetvolume(vol):
+    VOL_DOWN = 57348
+    VOL_UP = 57347
+    cmd = list()
+
+    for _ in range(21):
+        cmd.append(VOL_DOWN)
+    for _ in range(vol):
+        cmd.append(VOL_UP)
+
+    return cmd
+
+
+# Adaptation of "isRFBandLikeVOOevasion()" for Pool
+def isRFBandLikeVOOevasionPool(ip, port=5900, timeout=0.5, verbose=False):
+    if isRFBandLikeVOOevasion(ip, port, timeout, verbose):
+        return ip
+    return 0
+
+# Scan the default interface network (all the IPs on the  interface) to find .evasion box(es) and return a list of potential boxes.
+def scanRFB():
+    import netifaces
+    import ipaddress
+    from multiprocessing import Pool
+
+    default_iface = netifaces.gateways()['default'][netifaces.AF_INET]
+    addrs = netifaces.ifaddresses(default_iface[1])[netifaces.AF_INET]
+    ls = list()
+
+    for addr in addrs:
+        mask = ipaddress.ip_address(addr["netmask"]) # Extract and compute subnet mask
+        mask = format(int(mask), "32b")
+
+        cnt_0 = 0
+        cnt_1 = 0
+        for bit in mask:
+            if bit == "1" and cnt_0 == 0:
+                cnt_1 += 1
+            elif bit == "0":
+                cnt_0 += 1
+            else:
+                cnt_1 = -1
+                break
+        
+        if cnt_1 > 0:
+            mask = str(cnt_1)
+        else:
+            print('Error, invalid mask address.')
+        ip = addr["broadcast"].replace('255','0') + '/' + mask
+        net =  ipaddress.ip_network(ip)
+        
+        # Base IP address
+        print(net)
+
+        addresses = list()
+        
+        for x in net:
+            addresses.append(str(x))
+
+        # Configure pool (scaling depend of the number of CPU)
+        n = os.cpu_count()*25 #len(addresses)
+        if n>256:
+            n = 256
+        print("Pool size (max=256): " + str(n))
+
+        # Scan all the addresses with the help of a pool
+        with Pool(n) as p:
+            ls_evasion = p.map(isRFBandLikeVOOevasionPool, addresses)
+
+        # Clean the results
+        ls_evasion = purgeList(ls_evasion, 0)     
+        print(ls_evasion)
+        for ip in ls_evasion:
+            ls.append(ip)
+
+    print("Scan is done (" + str(len(ls)) + " address(es)).")
+    return ls
+
+# Display the list of valid know command (name and value)
+def displayCommand():
+    l = list(command.keys())
+    l.sort()
+    
+    for cmd in l:
+        print(cmd + " = " + str(command[cmd]))
+    return
+
+# Check the command validity (non case sensitive)
+def isValidCommand(temp_command):
+    if temp_command.upper() in command_ls:
+        return True
+    elif True:
+        try:
+            cmd = int(temp_command)
+            if cmd in command.values():
+                return True
+            else:
+                return False
+        except:
+            return False
+            
+    else:
+        return False
+
+# Convert a command (name or value to value)
+def convertCommandToValue(temp_command):
+    if isValidCommand(temp_command):
+        try:
+            return command[temp_command]
+        except:
+            return int(temp_command)
+
+# Convert a command (value to name or name to value)
+def convertCommand(temp_command):
+    try:
+        return command[temp_command]
+    except:
+        keys = list()
+        if keys==None:
+            print("NO KEY FOUND")
+        for key, val in command.items():
+            if val == int(temp_command):
+                keys.append(key)
+        if keys:
+            temp_str = ' or '
+            return temp_str.join(keys)
+        
+        raise NameError('Did not find the corresponding command name for this value')
+
+# Check the "type" in the parser for the port
+def type_port(astring):
+    try:
+        p = int(astring)
+        if p >= 0 and p <= 65535:
+            return astring
+        else:
+            raise argparse.ArgumentTypeError("Value should be an integer between 0 and 65535 included.")
+    except:
+        raise argparse.ArgumentTypeError("Value should be an integer between 0 and 65535 included.")
+
+# Check the "type" in the parser for the command
+def type_command(astring):
+    if isValidCommand(astring):
+        return astring
+    else:
+        raise argparse.ArgumentTypeError("Invalid command ('" + astring + "'), use '-lc' to list the valid commands")
+
+# Display the security type of the RFB connection
+def displaySecurityType(sec_type):
+    switcher = {
+        0: "Invalid",
+        1: "NONE",
+        2: "VNC Authentication"
+    } 
+    print(' security type: ' + str(sec_type) + ' (' + switcher.get(sec_type,"Not defined by IETF") +')' )
+
+# Generate a bytes array with the command to send (KEYDOWN_KEY, KEYUP_KEY)
+def genPacketFromCmd(cmd): #Set KEYUP, set KEYDOWN
+    return b'\x04\x01\x00\x00' + (cmd).to_bytes(4, byteorder='big') + b'\x04\x00\x00\x00' + (cmd).to_bytes(4, byteorder='big')
+
+# Convert a channel number in a sequence of command
+def channelToCommand(ch):
+    cmd_ls = list()
+    try:
+        ch_str = str(abs(ch))
+    except Exception as e:
+        print(e)
+        exit(1)
+    
+    for c in ch_str:
+        cmd_ls.append(convertCommandToValue('REMOTE_'+c))
+    cmd_ls.append(convertCommandToValue('OK'))
+    return cmd_ls
+
+# Send the command to the defined address
+def send_cmd(ip, port, cmd, timeout=None):
+    try:
+        with socket.socket(socket.AF_INET,socket.SOCK_STREAM) as vnc:
+            print("1. Initialize connection to:\n IP: " + ip + "\n Port: " + str(port))
+            if timeout and (type(timeout)==type(float()) or type(timeout)==type(int())):
+                vnc.settimeout(timeout)
+            vnc.connect((ip,5900))
+            vnc_ver = vnc.recv(12)
+            print("Receive RFB protocol version: " + str(vnc_ver))
+            vnc.send(vnc_ver)
+            print("Send back RFB protocol version: " + str(vnc_ver))
+            print("2. Receive security")
+            nb_sec_types = ord(vnc.recv(1))
+            #print(nb_sec_types.decode())
+            print("Nb security types: " + str(nb_sec_types))
+            
+            for _ in range(0, nb_sec_types):
+                sec_type = ord(vnc.recv(1))
+                displaySecurityType(sec_type)
+
+            ClientInit = b'\x01' 
+            print("3. Send ClientInit message: " + str(ClientInit)) # Send 1 byte
+            vnc.send(ClientInit) # 0 -> Non exclusive connection, 1 -> exclusive connection
+            ServerInit = vnc.recv(4096)
+            print("Receive ServerInit: " + str(ServerInit))
+            ClientEncodage = b'\x01' 
+            print("4. Send Client to server message: " + str(ClientEncodage)) # Send 1 byte
+            vnc.send(ClientEncodage)
+            ServerClient = vnc.recv(4096)
+            print("Receive from ServerClient: " + str(ServerClient))
+            if type(cmd) == type(str()):
+                print("5. Send command '" + str(cmd) + "': " + str(genPacketFromCmd(cmd)))
+                vnc.send(genPacketFromCmd(cmd))
+            elif type(cmd) == type(list()):
+                if len(cmd)>1:
+                    print("5. Send multiple commands:")
+                else:
+                    print("5. ", end="")
+                
+                for c in cmd:
+                    print("Send command '"+ str(c) + "': " + str(genPacketFromCmd(c)))
+                    vnc.send(genPacketFromCmd(c))
+            else:
+                raise NameError('In function send_cmd(), "cmd" should be a string or a list of string.')
+            return True, None
+    except Exception as e:
+        print(e)
+        return False, e
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", default=False,
+                        help="increase output verbosity",
+                        action="store_true")
+    parser.add_argument("-f", "--find", default=False,
+                        help="return a list of potential .evasion boxes.",
+                        action="store_true")
+    parser.add_argument("-s", "--status", default=False,
+                        help="return 'success' if the command has been send else it return 'fail'.",
+                        action="store_true")
+    parser.add_argument("-a", "--address", type=str,
+                        help="IP address of the .evasion box")
+    parser.add_argument("-p", "--port", type=type_port, default=5900,
+                        help="port of the .evasion box, default is 5900 [optional]")
+    parser.add_argument("-c", "--command", type=type_command, nargs='+',
+                        help="command to send to the .evasion box (the command is checked), name of the command and value are accepted")
+    parser.add_argument("-ch", "--channel", type=int,
+                        help="send the command to the .evasion box to change the channel (must be an integer)")
+    # NOT WORKING
+    #parser.add_argument("-vol", "--volume", type=int,
+    #                    help="send the command to the .evasion box to change the volume (must be an integer [0-20])")
+    # Not implemented
+    #parser.add_argument("-rc", "--raw_command", type=int,
+    #                    help="raw command wich will be send to the .evasion box (will be send as it is without check), must be an integer")
+    parser.add_argument("-cv", "--convert_command", type=type_command, nargs='+',
+                        help="convert a valid command from name to value or from value to name")
+    parser.add_argument("-lc", "--list_commands",
+                        help="display the list of known commands",
+                        action="store_true")
+    
+    args = parser.parse_args()
+
+    if args.verbose:
+        print("Python 3 based .evasion box API")
+        print("Verbosity turned on.\n")
+        print("Arguments:\n")
+        for arg, value in vars(args).items():
+            print("'" + arg + "': " + str(value))
+        print()
+             
+    if args.list_commands:
+        if args.verbose:
+            print("Display the list of valid know command for the .evasion box:\n")
+        displayCommand()
+        
+    if args.convert_command:
+        for cmd in args.convert_command:
+            with manageVerbose(args.verbose):
+                print(cmd + ": ", end='')
+            print(convertCommand(cmd.upper()))
+
+    if args.find:
+        print("Start scanning network (this is a CPU intensive task, which needs the 'netifaces' module):")
+        with manageVerbose(args.verbose):
+            evasion = scanRFB()
+
+        if len(evasion) > 0:
+            if len(evasion) == 1:
+                print("Potential .evasion box:")
+            else:
+                print("Potential .evasion boxes:")
+            for box in evasion:
+                print("IP: " + box)
+        else:
+            print("No box have been found.")
+
+    if args.address and args.channel:
+        try:
+            with manageVerbose(args.verbose):
+                cmd_ls = channelToCommand(args.channel)
+                print(cmd_ls)
+                result, error = send_cmd(args.address, args.port, cmd_ls)
+                    
+            if result and (args.status or args.verbose):
+                print('Success')
+            elif args.status or args.verbose:
+                print('Fail')
+                if args.verbose:
+                    print(error)
+
+        except Exception as e:
+            print(e)
+
+    """
+    NOT WORKING
+    if args.address and args.volume:
+        try:
+            with manageVerbose(args.verbose):
+                cmd_ls = commandToSetvolume(args.volume)
+                print(cmd_ls)
+                result, error = send_cmd(args.address, args.port, cmd_ls)
+                    
+            if result and (args.status or args.verbose):
+                print('Success')
+            elif args.status or args.verbose:
+                print('Fail')
+                if args.verbose:
+                    print(error)
+            
+        except Exception as e:
+            print(e)
+    """
+
+    if args.address and args.command:
+        try:
+            cmd_ls = list()
+            for cmd in args.command:
+                cmd_ls.append(convertCommandToValue(cmd.upper()))
+
+            with manageVerbose(args.verbose):
+                print(cmd_ls)
+                result, error = send_cmd(args.address, args.port, cmd_ls)
+                    
+            if result and (args.status or args.verbose):
+                print('Success')
+            elif args.status or args.verbose:
+                print('Fail')
+                if args.verbose:
+                    print(error)
+            
+        except Exception as e:
+            print(e)
+            
+    
+    """
+    # Create a socket to be used a client
+
+    socket.setdefaulttimeout(10)
+
+    timeout = socket.getdefaulttimeout()
+
+    print("System has default timeout of {} for create_connection".format(timeout))
+
+    
+    with socket.create_connection(("192.168.0.15",5900)) as s:
+        print("connected")
+        bytes2Send = str.encode("Hello server system!")
+        # s.sendall(bytes2Send)
+        # Receive the data
+
+        data = s.recv(1024)
+
+        print(data)
+    """
+if __name__ == '__main__':
+    main()

--- a/evasion_API_Python3/use_API_as_module.py
+++ b/evasion_API_Python3/use_API_as_module.py
@@ -1,0 +1,25 @@
+from evasion import manageVerbose, channelToCommand, send_cmd
+BOX = "192.168.0.15"
+
+def main():
+    while True:
+        try:
+            cmd = input("Entrer un numéro de chaîne : ")
+        except:
+            exit(0)
+
+        try:
+            ch = int(cmd)
+            # On fait taire les fonctions exécutées
+            with manageVerbose(verbose=False):
+                # On génère une liste de commandes
+                cmd_ls = channelToCommand(ch)
+                print(cmd_ls)
+                # On envoie la liste de commandes et on récupère le succès de l'envoie
+                r,_ = send_cmd(BOX, 5900, cmd_ls)
+            print("Envoie réussi" if r else "Envoie échoué")
+        except:
+            raise NameError('Le numéro de chaîne doit-être un entier')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Bonjour,

Je me suis permit d'utiliser vos recherches pour réaliser une API sous Python 3 pour la box .évasion de VOO.

Êtes-vous en mesure de la tester (je l'ai uniquement testée sur Windows et dans mon réseau)? L'idéal serait de voir si les options d'envoie de commandes et de recherche d'appareil fonctionne aussi chez vous.

Toutes les informations utiles sont dans le fichier `.evasion_API.md`, l'API correspond au fichier `evasion.py` et le fichier `use_API_as_module.py` est un exemple de l'utilisation de l'API en tant que module Python.

Je n'ai pas réussi à utiliser l'_UPnP_ pour détecter la box, donc je teste toutes les connexions et tente un handshake.

Bien à vous,
Vincent

P.S. : J'ai ajouté un fichier de license pour mon script explicitement.